### PR TITLE
fixed offset calculation for legends in Firefox developer edition

### DIFF
--- a/src/common/legend.js
+++ b/src/common/legend.js
@@ -1,6 +1,6 @@
 define([],function(){
-    return function(legendDiv,legendTitle,legendContent)
-    {
+    "use strict";
+    return function(legendDiv,legendTitle,legendContent) {
         return {
           onClick : function(d,e){
             //nothing...
@@ -15,8 +15,11 @@ define([],function(){
             var et = e.target;
             if (d && e){
 
-                var desiredLeft = ((e.offsetX !== undefined ? e.offsetX : e.layerX)-legendDiv.offsetLeft);
-                var desiredTop = ((e.offsetY !== undefined ? e.offsetY : e.layerY) -legendDiv.offsetTop);
+                var legendRect = legendDiv.getBoundingClientRect();
+                var desiredLeft = e.clientX - legendRect.left;
+                var desiredTop = e.clientY - legendRect.top;
+                //additional offset in order to avoid hiding information behind the popup
+                desiredTop -= 10;
 
                 var style = {
                              left:desiredLeft+"px",


### PR DESCRIPTION
These changes adjust the position of the legends as displayed in the Firefox Developer edition (FF 44.0a).

I tested these changes in:
- Firefox 44.0a
- Chromium 43.0
- Opera 30.0

Unfortunately, I do not have IE available, so you should check the changes in IE before merging this pull request.

(I also added `"use strict";` in order to enable the strict mode for JavaScript)
