### PR TITLE
Updated broken links

### DIFF
--- a/code-city/index.html
+++ b/code-city/index.html
@@ -35,7 +35,6 @@
             <div class="row">
                 <div class="col-md-12">
                         <h2>Code City</h2>
-                        <a class="btn btn-primary" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button"><strong>Live demo</strong></a>
                         <a href="../index.html" class="btn btn-default">Back to index</a>
                         <hr />
                         <p style="text-align:right">

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                 <p>
                     Please feel free to <strong><a href="https://github.com/quantifiedcode/code-is-beautiful">contribute</a></strong> your own visualizations.
                 </p>
-                <p><a class="btn btn-primary btn-lg" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button">Live demo</a> <a class="btn btn-default btn-lg" href="https://github.com/quantifiedcode/code-is-beautiful" role="button">Github</a></p>
+                <p><a class="btn btn-primary btn-lg" href="code-city/index.html" role="button">Live demo</a> <a class="btn btn-default btn-lg" href="https://github.com/quantifiedcode/code-is-beautiful" role="button">Github</a></p>
               </div>
               <div class="col-md-6">
                 <div class="text-right">
@@ -66,8 +66,7 @@
               <p><a href="code-city"><img class="thumb" src="assets/images/code_city.png" width="100%"/></a></p>
               <br/>
               <p>
-                <a class="btn btn-primary btn-lg" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button">Live demo</a>
-                <a class="btn btn-default btn-lg  margin-left-10" href="code-city/index.html" role="button">Details</a>
+                <a class="btn btn-primary btn-lg" href="code-city/index.html" role="button">Live demo</a>
               </p>
             </div>
             <div class="col-md-4 text-center">
@@ -75,8 +74,7 @@
               <p><a href="sunburst"><img class="thumb" src="assets/images/sunburst.png" width="100%"/></a></p>
               <br/>
               <p>
-                  <a class="btn btn-primary btn-lg" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button">Live demo</a>
-                  <a class="btn btn-default btn-lg margin-left-10" href="sunburst/index.html" role="button">Details</a>
+                  <a class="btn btn-primary btn-lg" href="sunburst/index.html" role="button">Live demo</a>
               </p>
            </div>
             <div class="col-md-4 text-center">
@@ -84,8 +82,7 @@
               <p><a href="stack"><img class="thumb" src="assets/images/stack.png" width="100%"/></a></p>
               <br/>
               <p>
-                  <a class="btn btn-primary btn-lg" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button">Live demo</a>
-                  <a class="btn btn-default btn-lg margin-left-10" href="stack/index.html" role="button">Details</a>
+                  <a class="btn btn-primary btn-lg" href="stack/index.html" role="button">Live demo</a>
               </p>
             </div>
           </div>

--- a/stack/index.html
+++ b/stack/index.html
@@ -45,7 +45,6 @@
                 <div class="col-md-12">
                     <p class="lead">
                     </p>
-                    <a class="btn btn-primary" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button"><strong>Live demo</strong></a>
                     <a href="../index.html" class="btn btn-default">Back to index</a>
                     <hr />
                     <div class="stack-chart-canvas" id="stack-chart-canvas">

--- a/sunburst/index.html
+++ b/sunburst/index.html
@@ -37,7 +37,6 @@
             <h2>Sunburst</h2>
             <div class="row">
                 <div class="col-md-4">
-                    <a class="btn btn-primary" href="https://www.quantifiedcode.com/app/code-is-beautiful" role="button"><strong>Live demo</strong></a>
                     <a href="../index.html" class="btn btn-default">Back to index</a>
                     <hr />
                     <p class="lead">


### PR DESCRIPTION
## Problem:
On http://quantifiedcode.github.io/code-is-beautiful/, there are multiple "Live Demo" links pointing to https://www.quantifiedcode.com/app/code-is-beautiful. The problem is the URL returns a 404. 

## Solution:
Since the Code Is Beautiful project homepage is hosted on GitHub, I  updated the "Live Demo" links to point to the GitHub path. Because of this, the "Details" buttons were removed because they would point to the same URLs.
Also the "Live Demo" buttons on the demo pages were removed because they redirect to the same page. 

## DEMO
https://www.larrybattle.me/code-is-beautiful/

<a href="https://www.larrybattle.me/code-is-beautiful/"><img src="https://user-images.githubusercontent.com/288263/47967264-3276f700-e021-11e8-943c-3f444d5afbf5.png"/></a>
